### PR TITLE
Update VDF Entry with missing fields

### DIFF
--- a/VDFParser/Models/VDFEntry.cs
+++ b/VDFParser/Models/VDFEntry.cs
@@ -2,6 +2,7 @@
 
     /// <summary>
     /// Represents a VDF entry
+    /// Reference: https://developer.valvesoftware.com/wiki/Add_Non-Steam_Game
     /// </summary>
     public class VDFEntry {
 
@@ -12,10 +13,17 @@
         public int Index { get; set; }
 
         /// <summary>
+        /// Gets or sets the appid of the app.
+        /// </summary>
+        /// <value>The id of the app.</value>
+        [VDFField("appid")]
+        public int appid { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the app.
         /// </summary>
         /// <value>The name of the app.</value>
-        [VDFField("appname")]
+        [VDFField("AppName")]
         public string AppName { get; set; }
 
         /// <summary>
@@ -27,7 +35,7 @@
         /// "/path/to/binary" -arg1 "argument with spaces"
         /// </summary>
         /// <value>The executable path.</value>
-        [VDFField("exe")]
+        [VDFField("Exe")]
         public string Exe { get; set; }
 
         /// <summary>

--- a/VDFParserTests/ParserTests.cs
+++ b/VDFParserTests/ParserTests.cs
@@ -20,6 +20,7 @@ namespace VDFParserTests {
         public void TestParsedContents() {
             var expectations = new VDFEntry[] {
                 new VDFEntry() {
+                    appid = 123456,
                     AppName = "Guitar Hero World Tour",
                     Exe = "\"D:\\Program Files\\GH\\GHWT.exe\"",
                     StartDir = "\"D:\\Program Files\\GH\\\"",
@@ -43,6 +44,7 @@ namespace VDFParserTests {
                 var par = entries[i];
 
                 Assert.AreEqual(exp.Index, par.Index);
+                Assert.AreEqual(exp.appid, par.appid);
                 Assert.AreEqual(exp.AppName, par.AppName);
                 Assert.AreEqual(exp.Exe, par.Exe);
                 Assert.AreEqual(exp.StartDir, par.StartDir);


### PR DESCRIPTION
Add the appid field and fixes the name of the exe and appname to use the same capitalization as expected by Steam

In the following binary comparison, it is possible to notice that the appid is removed from a file when it is re-serialized, and that the capitalization of some of the fields are changed, this probably interferes with what Steam expects, causing it to re-calculate the appid of an pre-existing shortcut, losing the connection to custom artworks in the library after the re-serialization done by projects using this library.
![image](https://user-images.githubusercontent.com/1337383/131267084-ee2b2254-c418-4dbe-9918-f5e6ca64c38d.png)
